### PR TITLE
Fix comparing _EOF with itself

### DIFF
--- a/dahuffman/huffmancodec.py
+++ b/dahuffman/huffmancodec.py
@@ -21,17 +21,18 @@ class _EndOfFileSymbol:
     def __repr__(self) -> str:
         return "_EOF"
 
-    # Because _EOF will be compared with normal symbols (strings, bytes),
-    # we have to provide a minimal set of comparison methods.
-    # We'll make _EOF smaller than the rest (meaning lowest frequency)
-    def __lt__(self, other) -> bool:
-        return True
-
-    def __gt__(self, other) -> bool:
-        return False
-
     def __eq__(self, other) -> bool:
         return other.__class__ == self.__class__
+
+    # Because _EOF will be compared with normal symbols (strings, bytes),
+    # we have to provide a minimal set of comparison methods. We'll make
+    # _EOF smaller than all values other than itself since there will
+    # always be 1 and only 1 end of file per file.
+    def __lt__(self, other) -> bool:
+        return self != other
+
+    def __gt__(self, other) -> bool:
+        return self == other
 
     def __hash__(self) -> int:
         return hash(self.__class__)

--- a/tests/test_eof.py
+++ b/tests/test_eof.py
@@ -1,0 +1,30 @@
+import pytest
+
+from dahuffman.huffmancodec import _EOF
+
+
+def test_eq():
+    assert _EOF == _EOF
+
+
+@pytest.fixture(params=(b'a', b'\0', b'_EOF'))
+def raw_value(request):
+    return request.param
+
+
+@pytest.fixture(params=(lambda b: b.decode('utf-8'), bytes, tuple))
+def of_type(request):
+    return request.param
+
+
+@pytest.fixture
+def to_compare(raw_value, of_type):
+    return of_type(raw_value)
+
+
+def test_lt(to_compare):
+    assert _EOF < to_compare
+
+
+def test_gt(to_compare):
+    assert to_compare > _EOF


### PR DESCRIPTION
### Changes

1. Make _EOF equal itself
2. Alter `__lt__` and `__gt__` to use equality check
3. Add tests for both old and new _EOF comparison behavior

Code quality tasks:
- [x] Ran pytest
- [x] Ran [the `flake8` steps specified in `.github/workflows/lint-and-test.yml`[(https://github.com/pushfoo/python-dahuffman/blob/93d9e7b73e7582b9651ab567a69b3ac1c3cb624e/.github/workflows/lint-and-test.yml#L36-L38)
